### PR TITLE
171 - Filtrar Novedades por categorias (Backoffice)

### DIFF
--- a/src/Components/News/Table/NewsTable.js
+++ b/src/Components/News/Table/NewsTable.js
@@ -22,14 +22,9 @@ export default function NewsTable() {
       width: 70,
 
       renderCell: (params) => {
-        const onClick = (e) => {
-          e.stopPropagation()
-          console.log('action->', params.field, 'id->', params.id)
-        }
-
         return (
           <Button component={Link} to={`/backoffice/news/create/${params.id}`}>
-            <EditIcon color="primary" onClick={onClick} />
+            <EditIcon color="primary" />
           </Button>
         )
       },

--- a/src/Services/apiServices/newsApiService.js
+++ b/src/Services/apiServices/newsApiService.js
@@ -10,7 +10,6 @@ const newsGetUrl = process.env.REACT_APP_API_NEWS_GET
 const newsPostUrl = process.env.REACT_APP_API_NEWS_POST
 const newsPutUrl = process.env.REACT_APP_API_NEWS_PUT
 const newsDeleteUrl = process.env.REACT_APP_API_NEWS_DELETE
-const newsSearchUrl = '/news?search='
 
 export const getNews = (id) => {
   return getPublicHandler(newsGetUrl, id)
@@ -28,6 +27,9 @@ export const deleteNews = (id) => {
   return deletePrivateHandler(newsDeleteUrl, id)
 }
 
-export const searchNews = (name) => {
-  return searchPrivateHandler(newsSearchUrl, name)
+export const searchNews = (name, category) => {
+  return searchPrivateHandler(
+    newsGetUrl,
+    `?search=${name}&category=${category}`,
+  )
 }

--- a/src/features/news/newsReducer.js
+++ b/src/features/news/newsReducer.js
@@ -24,9 +24,9 @@ export const fetchNew = createAsyncThunk('news/getNews', async () => {
 // For backoffice
 export const fetchSearchNews = createAsyncThunk(
   'news/searchNews',
-  async (val) => {
+  async (search) => {
     try {
-      const response = await searchNews(val)
+      const response = await searchNews(search.name, search.category)
       return response.data
     } catch (error) {
       throw new Error(error)


### PR DESCRIPTION
Basandose en el componente de busqueda de novedades, se deberá agregar al formulario un selector de categorias para poder realizar busqueda de novedades por titulo y categoria.
Se deberá:
-Cargar el selector de categorias obteniendo las mismas desde el backend, agregando la opcion "todas".

Validar que el administrador haya seleccionado una categoria diferente a "todas", de ser asi, realizar la petición al endpoint /news?search={valorBuscado]&category={categoriaSeleccionada}

Si el usuasrio selecciona la opcion"todas" las categorias, se deben seguir las mismas condiciones que en la busqueda por titulo.