### PR TITLE
OT128-113 create organization reducer

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -6,6 +6,7 @@ import usersReducer from '../features/backofficeUsers/usersReducer'
 import membersReducer from '../features/members/membersReducer'
 import newsReducer from '../features/news/newsReducer'
 import slidesReducer from '../features/auth/slide/slidesReducer'
+import organizationReducer from '../features/organization/organizationReducer'
 
 const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ const store = configureStore({
     activities: activitiesReducer,
     news: newsReducer,
     slides: slidesReducer,
+    organization: organizationReducer,
   }, //add reducers
 })
 export default store

--- a/src/features/organization/organizationReducer.js
+++ b/src/features/organization/organizationReducer.js
@@ -1,0 +1,43 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import axios from 'axios'
+
+const initialState = {
+  data: {},
+  status: '',
+}
+
+//Export to RegisterForm submitHandle => catch Error
+export const getOrganizationData = createAsyncThunk(
+  'organization/getOrganizationData',
+  async (data, { rejectWithValue }) => {
+    try {
+      const response = await axios.get(
+        'http://ongapi.alkemy.org/api/organizations',
+      )
+      return response.data
+    } catch {
+      return rejectWithValue({ error: 'error' })
+    }
+  },
+)
+
+export const organizationReducer = createSlice({
+  name: 'organization',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(getOrganizationData.pending, (state) => {
+        state.status = 'pending'
+      })
+      .addCase(getOrganizationData.fulfilled, (state, action) => {
+        state.data = action.payload.data
+        state.status = action.payload.success
+      })
+      .addCase(getOrganizationData.rejected, (state, action) => {
+        state.status = action.payload.error
+      })
+  },
+})
+
+export default organizationReducer.reducer


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT128/boards/195?modal=detail&selectedIssue=OT128-113

Criterios de aceptacion: Utilizando redux-toolkit, desarrollar un reducer para gestionar el estado de Nosotros. El mismo deberá tener una acción para renderizar el listado en su respectivo componente.

La lógica existente de peticiones a la API deberá moverse a thunks asíncronos dentro del reducer. 